### PR TITLE
イベントタイプの型情報を追加

### DIFF
--- a/src/garoon.d.ts
+++ b/src/garoon.d.ts
@@ -3,8 +3,27 @@
 
 declare namespace garoon {
     namespace events {
+        type EventType =
+            | 'schedule.event.create.show'
+            | 'schedule.event.create.submit'
+            | 'schedule.event.edit.show'
+            | 'schedule.event.edit.submit'
+            | 'schedule.event.detail.show'
+            | 'schedule.calendar.groupDayIndex.show'
+            | 'schedule.calendar.groupWeekIndex.show'
+            | 'schedule.calendar.dayIndex.show'
+            | 'schedule.calendar.weekIndex.show'
+            | 'schedule.calendar.monthIndex.show'
+            | 'message.body.create.show'
+            | 'message.body.changeTo.show'
+            | 'workflow.request.create.show'
+            | 'workflow.request.detail.show'
+            | 'workflow.request.approve.show'
+            | 'workflow.request.print.show'
+            | 'workflow.request.approve.submit.success';
+
         function on(
-            event: string | string[],
+            event: EventType | EventType[],
             handler: (event: any) => any
         ): void;
     }


### PR DESCRIPTION
イベントハンドラー（garoon.events.on）が受け取るイベントタイプを以下のいずれかに限定しました。

- `schedule.event.create.show` // 予定の登録画面が表示されたときのイベント
- `schedule.event.create.submit` // 予定の登録画面の保存実行前イベント
- `schedule.event.edit.show` // 予定の変更画面が表示されたときのイベント
- `schedule.event.edit.submit` // 予定の変更画面の保存実行前イベント
- `schedule.event.detail.show` // 予定の詳細画面が表示されたときのイベント
- `schedule.calendar.groupDayIndex.show` // グループ日画面が表示されたときのイベント
- `schedule.calendar.groupWeekIndex.show` // グループ週画面が表示されたときのイベント
- `schedule.calendar.dayIndex.show` // 日画面が表示されたときのイベント
- `schedule.calendar.weekIndex.show` // 週画面が表示されたときのイベント
- `schedule.calendar.monthIndex.show` // 月画面が表示されたときのイベント
- `message.body.create.show` // メッセージの作成画面が表示されたときのイベント
- `message.body.changeTo.show` // メッセージの宛先変更画面が表示されたときのイベント
- `workflow.request.create.show` // ワークフロー申請の作成画面が表示されたときのイベント
- `workflow.request.detail.show` // ワークフロー申請の詳細画面が表示されたときのイベント
- `workflow.request.approve.show` // ワークフロー申請の承認画面が表示されたときのイベント
- `workflow.request.print.show` // ワークフロー申請の印刷用画面が表示されたときのイベント
- `workflow.request.approve.submit.success` // ワークフロー申請が承認されたときのイベント