### PR TITLE
garoon.schedule.event.insertTableRow() を追加

### DIFF
--- a/src/garoon.d.ts
+++ b/src/garoon.d.ts
@@ -76,11 +76,20 @@ declare namespace garoon {
 
     namespace schedule {
         namespace event {
+            type ItemCode =
+                | 'DATE_AND_TIME'
+                | 'ATTENDEES'
+                | 'NOTES';
             function get(): garoon.types.schedule.Event;
             function set(
                 event: garoon.types.schedule.Event
             ): void;
             function getHeaderSpaceElement(): HTMLElement | null;
+            function insertTableRow(
+                label: string,
+                description: string | HTMLElement,
+                item_code?: ItemCode
+            ): void;
         }
         namespace calender {
             type ViewType =


### PR DESCRIPTION
予定の詳細画面のテーブルに行を追加する `garoon.schedule.event.insertTableRow()` の型情報を追加しました。

参考: https://developer.cybozu.io/hc/ja/articles/360034653772