### PR TITLE
garoon.workflow.request.setItemEditable() を追加

### DIFF
--- a/src/garoon.d.ts
+++ b/src/garoon.d.ts
@@ -124,6 +124,10 @@ declare namespace garoon {
             function getSpaceElement(
                 code: string
             ): HTMLElement | null;
+            function setItemEditable(
+                itemCode: string | string[],
+                status: boolean
+            ): void;
         }
     }
 }


### PR DESCRIPTION
申請フォーム項目の編集可/不可を切り替える `garoon.workflow.request.setItemEditable()` の型情報を追加しました。

参考: https://developer.cybozu.io/hc/ja/articles/360026753011