### PR TITLE
garoon.base.proxy.send() を追加

### DIFF
--- a/src/garoon.d.ts
+++ b/src/garoon.d.ts
@@ -27,6 +27,24 @@ declare namespace garoon {
         namespace request {
             function getRequestToken(): string;
         }
+        namespace proxy {
+            function send(
+                proxyCode: string,
+                url: string,
+                method: HttpMethod,
+                headers: any,
+                data: any,
+                callback: (response: any) => any,
+                error: (response: any) => any
+            ): void;
+            function send(
+                proxyCode: string,
+                url: string,
+                method: HttpMethod,
+                headers: any,
+                data: any
+            ): garoon.Promise<any>;
+        }
     }
 
     namespace connect {


### PR DESCRIPTION
外部APIの実行をする `garoon.base.proxy.send()` の型情報を追加しました。

参考: https://developer.cybozu.io/hc/ja/articles/115003522366