### PR TITLE
garoon.assets.images.getUrl() を追加

### DIFF
--- a/src/garoon.d.ts
+++ b/src/garoon.d.ts
@@ -126,4 +126,10 @@ declare namespace garoon {
             ): HTMLElement | null;
         }
     }
+
+    namespace assets {
+        namespace images {
+            function getUrl(fileKey: string): string;
+        }
+    }
 }


### PR DESCRIPTION
ファイルキーから画像URLを取得する `garoon.assets.images.getUrl()` の型情報を追加しました。

参考: https://developer.cybozu.io/hc/ja/articles/360026510732